### PR TITLE
perf: improve environment loading

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,4 +9,5 @@ lean_lib «Lean4Checker» { }
 @[default_target]
 lean_exe «lean4checker» {
   root := `Main
+  supportInterpreter := true
 }


### PR DESCRIPTION
There are three main optimizations here:

* Use `finalizeImports` only once instead of twice (we import the before environment and handle the after module data specially)
* Using the module data we have direct access to the new decls and don't need to diff two huge hashmaps
* Use a StateRefT for the state